### PR TITLE
Add ejson_wrapper decrypt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Or install it yourself as:
 
 ### Decrypting EJSON files
 
+From Ruby:
+
 ```
 # Private key is in /opt/ejson/keys
 EJSONWrapper.decrypt('myfile.ejson')
@@ -38,6 +40,20 @@ EJSONWrapper.decrypt('myfile.ejson', private_key: 'be8597abaa68bbfa23193624b1ed5
 # Private key is stored inside the ejson file itself as _private_key_enc (encrypted with KMS & Base64 encoded)
 EJSONWrapper.decrypt('myfile.ejson', use_kms: true, region: 'ap-southeast-2')
 => { :my_api_key => 'secret' }
+```
+
+Command line:
+
+```
+# decrypt all
+$ ejson_wrapper decrypt --file file.ejson --region us-east-1
+{
+  "datadog_api_token": "[datadog_api_token]"
+}
+
+# decrypt & extract a specific secret
+$ ejson_wrapper decrypt --file file.ejson --region us-east-1 --secret datadog_api_token
+[datadog_api_token]
 ```
 
 ### Generating EJSON files

--- a/exe/ejson_wrapper
+++ b/exe/ejson_wrapper
@@ -20,27 +20,21 @@ option_parser = OptionParser.new do |opts|
     options[:kms_key_id] = v
   end
 
-  opts.on('--file F', String, 'EJSON file to write') do |v|
+  opts.on('--file F', String, 'EJSON file to read or write') do |v|
     options[:file] = v
+  end
+
+  opts.on('--secret S', String, 'Secret to extract') do |v|
+    options[:secret] = v
   end
 end
 
 command = ARGV[0]
-unless command == 'generate'
-  STDERR.puts option_parser.banner
-  exit 1
-end
 
 option_parser.parse!
 
 if options[:region].nil?
   STDERR.puts "Missing --region option"
-  STDERR.puts option_parser
-  exit 1
-end
-
-if options[:kms_key_id].nil?
-  STDERR.puts "Missing --kms-key-id option"
   STDERR.puts option_parser
   exit 1
 end
@@ -51,6 +45,30 @@ if options[:file].nil?
   exit 1
 end
 
-EJSONWrapper.generate(region: options[:region],
-                      kms_key_id: options[:kms_key_id],
-                      file: options[:file])
+case command
+when 'generate'
+  if options[:kms_key_id].nil?
+    STDERR.puts "Missing --kms-key-id option"
+    STDERR.puts option_parser
+    exit 1
+  end
+
+  EJSONWrapper.generate(region: options[:region],
+                        kms_key_id: options[:kms_key_id],
+                        file: options[:file])
+when 'decrypt'
+  decrypted_secrets = EJSONWrapper.decrypt(options[:file], use_kms: true, region: options[:region])
+  if options[:secret]
+    secret = options[:secret].to_sym
+    unless decrypted_secrets.key?(secret)
+      STDERR.puts "Secret not found"
+      exit 1
+    end
+    puts decrypted_secrets.fetch(secret)
+  else
+    puts JSON.pretty_generate(decrypted_secrets)
+  end
+else
+  STDERR.puts option_parser.banner
+  exit 1
+end


### PR DESCRIPTION
Shows the whole decrypted JSON file or a specific secret if `--secret` is given.

Context: I want to use this to do the following:

```
bundle exec ejson_wrapper decrypt --region $region --file parameter_store.ejson |
  bundle exec ejson2parameterstore --region $region --kms-key-id arn:aws:kms:$region:$account_id:alias/...
```