### PR TITLE
Support ejson 1.2

### DIFF
--- a/lib/ejson_wrapper/generate.rb
+++ b/lib/ejson_wrapper/generate.rb
@@ -24,7 +24,7 @@ module EJSONWrapper
     end
 
     def invoke_ejson_keygen
-      stdout, status = Open3.capture2('ejson', 'keygen')
+      stdout, status = Open3.capture2e('ejson', 'keygen')
       raise KeygenFailed, stdout unless status.success?
       stdout
     end

--- a/spec/ejson_wrapper/generate_spec.rb
+++ b/spec/ejson_wrapper/generate_spec.rb
@@ -19,7 +19,7 @@ EOS
     allow(File).to receive(:write)
     allow(Aws::KMS::Client).to receive(:new).and_return(kms_client)
     allow(kms_client).to receive(:encrypt).and_return(encrypt_response)
-    allow(Open3).to receive(:capture2).with('ejson', 'keygen').and_return([ejson_keygen, double(:'success?' => true)])
+    allow(Open3).to receive(:capture2e).with('ejson', 'keygen').and_return([ejson_keygen, double(:'success?' => true)])
     described_class.new.call(region: 'ap-southeast-2', kms_key_id: key_id, file: file)
   end
 


### PR DESCRIPTION
In 1.2 ejson [started printing keys generated to stderr](https://github.com/Shopify/ejson/issues/55), this seems to be inadvertent. But this change will also make it easier to debug if there are any errors generating keys.