### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ $ cat myfile.ejson
 
 You now can add secrets into the EJSON file, in following example `my_api_key` in plaintext entry is added:
 
-``
+```
 # myfile.ejson
 {
   "_public_key": "[public_key]",
   "_private_key_enc":"[base64_encoded_encrypted_private_key]",
   "my_api_key": "plaintext"
 }
-``
+```
 
 to encrypt the secrets, run following command:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EJSON Wrapper
 
-Wraps the [`ejson`](https://github.com/Shopify/ejson) program to safely execute it and parse the resulting JSON. Additionally it offers a feature to encrypt/decrypt private key with AWS KMS (stored as `_private_key_enc` in EJSON file).
+Wraps the [`ejson`](https://github.com/Shopify/ejson) program to safely execute it and parse the resulting JSON. Additionally it offers a feature to encrypt/decrypt secrets with encrypted private key using AWS KMS.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EJSON Wrapper
 
-Wraps the [`ejson`](https://github.com/Shopify/ejson) program to safely execute it and parse the resulting JSON. Additonally it offers new a feature to encrypt/decrypt private key (stored as `_private_key_enc` in EJSON file) with AWS KMS.
+Wraps the [`ejson`](https://github.com/Shopify/ejson) program to safely execute it and parse the resulting JSON. Additionally it offers a feature to encrypt/decrypt private key with AWS KMS (stored as `_private_key_enc` in EJSON file).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -64,42 +64,60 @@ $ ejson_wrapper decrypt --file file.ejson --region us-east-1 --secret my_api_key
 
 ### Generating EJSON files
 
-Ensure your application has [AWS IAM Permission to encrypt with KMS](https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-encrypt-decrypt-specific-cmks) and your EJSON file must contain public key and unencrypted private key in `_public_key` and `_private_key_env` respectively.
+Ensure your application has [AWS IAM Permission to encrypt with KMS](https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-encrypt-decrypt-specific-cmks).
 
-```
-$ cat myfile.ejson
-{
-  "_public_key": "[public_key]",
-  "_private_key_enc":"[unencrypted_private_key]",
-  "my_secret": "secret"
-}
-```
+Firstly, the EJSON is generated to have public key and Base64 encoded & encrypted private key in `_public_key` and `_private_key_enc` respectively with:
 
-In Ruby code:
-
-```
-# Generate encrypted EJSON file (overwritting the unencrypted EJSON file)
-EJSONWrapper.generate(region: 'AWS_REGION', kms_key_id: 'key_id', file: 'myfile.ejson')
-=> Generated EJSON file myfile.ejson
-```
-
-OR
-
-Command line:
+Using CLI:
 
 ```
 $ ejson_wrapper generate --region $AWS_REGION --kms-key-id [key_id] --file myfile.ejson
 Generated EJSON file myfile.ejson
 ```
 
-To verify, check to see `_private_key_enc` and other secrets are encrypted:
+OR Ruby code:
+
+```
+# Generate encrypted EJSON file (overwritting the unencrypted EJSON file)
+EJSONWrapper.generate(region: ENV['AWS_REGION'], kms_key_id: 'key_id', file: 'myfile.ejson')
+=> Generated EJSON file myfile.ejson
+```
+
+Verify to ensure the new file contain the two required keys:
 
 ```
 $ cat myfile.ejson
 {
   "_public_key": "[public_key]",
-  "_private_key_enc":"[encrypted_private_key]",
-  "my_secret": "encrypted_secret"
+  "_private_key_enc":"[base64_encoded_encrypted_private_key]",
+}
+```
+
+You now can add secrets into the EJSON file, in following example, `my_api_key` in plaintext entry is added:
+
+``
+# myfile.ejson
+{
+  "_public_key": "[public_key]",
+  "_private_key_enc":"[base64_encoded_encrypted_private_key]",
+  "my_api_key": "plaintext"
+}
+``
+
+to encrypt the secrets, run following command:
+
+```
+$ ejson encrypt myfile.ejson
+```
+
+Verify to ensure the secret is encrypted correctly:
+
+```
+$ cat myfile.ejson
+{
+  "_public_key": "[public_key]",
+  "_private_key_enc":"[base64_encoded_encrypted_private_key]",
+  "my_api_key": "encrypted_secret"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EjsonWrapper
+# EJSON Wrapper
 
-Wraps the EJSON go program to safely execute it and parse the resulting JSON.
+Wraps the [`ejson`](https://github.com/Shopify/ejson) program to safely execute it and parse the resulting JSON. Additonally it offers new a feature to encrypt/decrypt private key (stored as `_private_key_enc` in EJSON file) with AWS KMS.
 
 ## Installation
 
@@ -12,17 +12,23 @@ gem 'ejson_wrapper'
 
 And then execute:
 
-    $ bundle
+```
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install ejson_wrapper
+```
+$ gem install ejson_wrapper
+```
 
 ## Usage
 
 ### Decrypting EJSON files
 
-From Ruby:
+Ensure your application has [AWS IAM Permission to decrypt with KMS](https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-encrypt-decrypt-specific-cmks).
+
+In Ruby code:
 
 ```
 # Private key is in /opt/ejson/keys
@@ -48,24 +54,52 @@ Command line:
 # decrypt all
 $ ejson_wrapper decrypt --file file.ejson --region us-east-1
 {
-  "datadog_api_token": "[datadog_api_token]"
+  "my_api_key": "[secret]"
 }
 
 # decrypt & extract a specific secret
-$ ejson_wrapper decrypt --file file.ejson --region us-east-1 --secret datadog_api_token
-[datadog_api_token]
+$ ejson_wrapper decrypt --file file.ejson --region us-east-1 --secret my_api_key
+[secret]
 ```
 
 ### Generating EJSON files
 
-```
-$ ejson_wrapper generate --region ap-southeast-2 --kms-key-id [key_id] --file file.ejson
-Generated EJSON file file.ejson
+Ensure your application has [AWS IAM Permission to encrypt with KMS](https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-encrypt-decrypt-specific-cmks) and your EJSON file must contain public key and unencrypted private key in `_public_key` and `_private_key_env` respectively.
 
-$ cat file.ejson
+```
+$ cat myfile.ejson
 {
   "_public_key": "[public_key]",
-  "_private_key_enc":"[encrypted_private_key]"
+  "_private_key_enc":"[unencrypted_private_key]",
+  "my_secret": "secret"
+}
+```
+
+In Ruby code:
+
+```
+# Generate encrypted EJSON file (overwritting the unencrypted EJSON file)
+EJSONWrapper.generate(region: 'AWS_REGION', kms_key_id: 'key_id', file: 'myfile.ejson')
+=> Generated EJSON file myfile.ejson
+```
+
+OR
+
+Command line:
+
+```
+$ ejson_wrapper generate --region $AWS_REGION --kms-key-id [key_id] --file myfile.ejson
+Generated EJSON file myfile.ejson
+```
+
+To verify, check to see `_private_key_enc` and other secrets are encrypted:
+
+```
+$ cat myfile.ejson
+{
+  "_public_key": "[public_key]",
+  "_private_key_enc":"[encrypted_private_key]",
+  "my_secret": "encrypted_secret"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Wraps the [`ejson`](https://github.com/Shopify/ejson) program to safely execute it and parse the resulting JSON. Additionally it offers a feature to encrypt/decrypt private key with AWS KMS (stored as `_private_key_enc` in EJSON file).
 
+## Prerequisites
+
+* [`ejson`](https://github.com/Shopify/ejson) application
+* Path to `ejson` binary is included in `PATH` environment variable
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -93,7 +98,7 @@ $ cat myfile.ejson
 }
 ```
 
-You now can add secrets into the EJSON file, in following example, `my_api_key` in plaintext entry is added:
+You now can add secrets into the EJSON file, in following example `my_api_key` in plaintext entry is added:
 
 ``
 # myfile.ejson


### PR DESCRIPTION
## Context

The README lacks details on what this gem offers and examples on how to generate EJSON secrets with Ruby code. This ambiguity makes the job hard for whom who are evaluating the gem harder. I hope this PR would clarify more context for public users.

## Changes

* Add special feature this gem offers
* Add more example on how to generate EJSON