### PR TITLE
Command for showing the private key

### DIFF
--- a/ejson_wrapper.gemspec
+++ b/ejson_wrapper.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ejson"
   spec.add_dependency "aws-sdk-kms"
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/exe/ejson_wrapper
+++ b/exe/ejson_wrapper
@@ -10,7 +10,7 @@ options = {
   kms_key_id: nil
 }
 option_parser = OptionParser.new do |opts|
-  opts.banner = 'Usage: ejson_wrapper generate [options]'
+  opts.banner = 'Usage: ejson_wrapper {generate,decrypt,reveal_key} [options]'
 
   opts.on('--region R', String, 'AWS Region') do |v|
     options[:region] = v

--- a/exe/ejson_wrapper
+++ b/exe/ejson_wrapper
@@ -68,6 +68,15 @@ when 'decrypt'
   else
     puts JSON.pretty_generate(decrypted_secrets)
   end
+
+when 'reveal_key'
+  begin
+    puts EJSONWrapper.private_key_decrypted(options[:file], region: options[:region])
+  rescue Errno::ENOENT
+    STDERR.puts "Secrets file not found"
+    exit 1
+  end
+
 else
   STDERR.puts option_parser.banner
   exit 1

--- a/lib/ejson_wrapper.rb
+++ b/lib/ejson_wrapper.rb
@@ -6,12 +6,16 @@ require "ejson_wrapper/generate"
 module EJSONWrapper
   def self.decrypt(file_path, key_dir: nil, private_key: nil, use_kms: false, region: nil)
     if use_kms
-      private_key = DecryptPrivateKeyWithKMS.call(file_path, region: region)
+      private_key = private_key_decrypted(file_path, region: region)
     end
     DecryptEJSONFile.call(file_path, key_dir: key_dir, private_key: private_key)
   end
 
   def self.generate(**args)
     Generate.new.call(**args)
+  end
+
+  def self.private_key_decrypted(file_path, region: nil)
+    DecryptPrivateKeyWithKMS.call(file_path, region: region)
   end
 end

--- a/lib/ejson_wrapper/decrypt_private_key_with_kms.rb
+++ b/lib/ejson_wrapper/decrypt_private_key_with_kms.rb
@@ -14,7 +14,7 @@ module EJSONWrapper
     def call(ejson_file_path, region:)
       ejson_hash = JSON.parse(File.read(ejson_file_path))
       encrypted_private_key = ejson_hash.fetch(KEY) do
-        raise PrivateKeyNotFound, "Private key was not found in ejson file under key #{key}"
+        raise PrivateKeyNotFound, "Private key was not found in ejson file under key #{KEY}"
       end
       decrypt(Base64.decode64(encrypted_private_key), region: region)
     end

--- a/spec/ejson_wrapper_spec.rb
+++ b/spec/ejson_wrapper_spec.rb
@@ -5,82 +5,119 @@ RSpec.describe EJSONWrapper do
   let(:ejson_tempfile) { Tempfile.new('ejson') }
   let(:ejson_contents) { %'{"_public_key":"#{public_key}","secret":"#{encrypted_secret}"}' }
 
-  def decrypt(file_path, **args)
-    EJSONWrapper.decrypt(file_path, **args)
-  end
-
-  context "when the ejson file doesn't exist" do
-    it 'raises an error' do
-      expect { decrypt('/tmp/unkown_blah_123909u2309') }.to raise_error(EJSONWrapper::DecryptionFailed)
-    end
-  end
-
-  context 'when the ejson file exists' do
-    before do
-      ejson_tempfile.write(ejson_contents)
-      ejson_tempfile.close
+  context "decrypt" do
+    def decrypt(file_path, **args)
+      EJSONWrapper.decrypt(file_path, **args)
     end
 
-    it 'decrypts the file given a keydir with the private key' do
-      Dir.mktmpdir do |key_dir|
-        File.write(File.join(key_dir, public_key), private_key)
-        decrypted_secrets = decrypt(ejson_tempfile.path, key_dir: key_dir)
-        expect(decrypted_secrets[:secret]).to eq 'sssh!'
+    context "when the ejson file doesn't exist" do
+      it 'raises an error' do
+        expect { decrypt('/tmp/unkown_blah_123909u2309') }.to raise_error(EJSONWrapper::DecryptionFailed)
       end
     end
 
-    it 'decrypts given a private key argument' do
-      decrypted_secrets = decrypt(ejson_tempfile.path, private_key: private_key)
-      expect(decrypted_secrets[:secret]).to eq 'sssh!'
+    context 'when the ejson file exists' do
+      before do
+        ejson_tempfile.write(ejson_contents)
+        ejson_tempfile.close
+      end
+
+      it 'decrypts the file given a keydir with the private key' do
+        Dir.mktmpdir do |key_dir|
+          File.write(File.join(key_dir, public_key), private_key)
+          decrypted_secrets = decrypt(ejson_tempfile.path, key_dir: key_dir)
+          expect(decrypted_secrets[:secret]).to eq 'sssh!'
+        end
+      end
+
+      it 'decrypts given a private key argument' do
+        decrypted_secrets = decrypt(ejson_tempfile.path, private_key: private_key)
+        expect(decrypted_secrets[:secret]).to eq 'sssh!'
+      end
+
+      it "doesn't include _public_key or _private_key_enc in the decrypted secrets" do
+        decrypted_secrets = decrypt(ejson_tempfile.path, private_key: private_key)
+        expect(decrypted_secrets.key?(:_public_key)).to eq false
+        expect(decrypted_secrets.key?(:_private_key_enc)).to eq false
+      end
+
+      it "doesn't supply a key dir env var when it's not supplied as an argument" do
+        decrypted_secrets = '{"api_key_1": "my-secret-api-key"}'
+        allow(Open3).to receive(:capture2).and_return([decrypted_secrets, double(success?: true)])
+        decrypt(ejson_tempfile.path)
+        expect(Open3).to have_received(:capture2).with({}, 'ejson', 'decrypt', ejson_tempfile.path, {})
+      end
+
+      context 'when the ejson file has a _private_key_enc key and use_kms: true' do
+        let(:ejson_contents) { %'{"_public_key":"#{public_key}","secret":"#{encrypted_secret}", "_private_key_enc": "#{private_key_enc}"}' }
+        let(:private_key_enc) { "priv-key-enc" }
+
+        before do
+          client = instance_double(Aws::KMS::Client)
+          allow(Aws::KMS::Client).to receive(:new).and_return(client)
+          response = double(plaintext: private_key)
+          allow(client).to receive(:decrypt).with(ciphertext_blob: Base64.decode64(private_key_enc)).and_return(response)
+        end
+
+        it 'decrypts with KMS' do
+          decrypted_secrets = decrypt(ejson_tempfile.path, use_kms: true)
+          expect(decrypted_secrets[:secret]).to eq 'sssh!'
+        end
+      end
+
+      context 'when the stdout of ejson contains invalid JSON' do
+        let(:decrypted_secrets) { '{"api_key_1": "my-secret-api-key", "' }
+
+        before do
+          allow(Open3).to receive(:capture2).and_return([decrypted_secrets, double(success?: true)])
+        end
+
+        it "doesn't throw an error with the contents of the decrypted JSON" do
+          expect { decrypt(ejson_tempfile.path) }.to raise_error { |error|
+            expect(error.message).to_not include('my-secret-api-key')
+          }
+        end
+
+        it 'throws a decryption failed error' do
+          expect {
+            decrypt(ejson_tempfile.path)
+          }.to raise_error(EJSONWrapper::DecryptionFailed, /Failed to parse/)
+        end
+      end
+    end
+  end
+
+  context 'reveal_key' do
+    def reveal_key(file_path, **args)
+      EJSONWrapper.private_key_decrypted(file_path, region: args[:region])
     end
 
-    it "doesn't include _public_key or _private_key_enc in the decrypted secrets" do
-      decrypted_secrets = decrypt(ejson_tempfile.path, private_key: private_key)
-      expect(decrypted_secrets.key?(:_public_key)).to eq false
-      expect(decrypted_secrets.key?(:_private_key_enc)).to eq false
+    context "when the ejson file doesn't exist" do
+      it 'raises an error' do
+        expect { reveal_key('/tmp/unkown_blah_123909u2309') }.to raise_error(Errno::ENOENT)
+      end
     end
 
-    it "doesn't supply a key dir env var when it's not supplied as an argument" do
-      decrypted_secrets = '{"api_key_1": "my-secret-api-key"}'
-      allow(Open3).to receive(:capture2).and_return([decrypted_secrets, double(success?: true)])
-      decrypt(ejson_tempfile.path)
-      expect(Open3).to have_received(:capture2).with({}, 'ejson', 'decrypt', ejson_tempfile.path, {})
-    end
-
-    context 'when the ejson file has a _private_key_enc key and use_kms: true' do
+    context 'when the ejson file exists' do
       let(:ejson_contents) { %'{"_public_key":"#{public_key}","secret":"#{encrypted_secret}", "_private_key_enc": "#{private_key_enc}"}' }
       let(:private_key_enc) { "priv-key-enc" }
+      let(:kms_client) { instance_double(Aws::KMS::Client) }
+      let(:kms_response) { instance_double(Aws::KMS::Types::DecryptResponse, plaintext: private_key) }
 
       before do
-        client = instance_double(Aws::KMS::Client)
-        allow(Aws::KMS::Client).to receive(:new).and_return(client)
-        response = double(plaintext: private_key)
-        allow(client).to receive(:decrypt).with(ciphertext_blob: Base64.decode64(private_key_enc)).and_return(response)
+        ejson_tempfile.write(ejson_contents)
+        ejson_tempfile.close
+
+        allow(Aws::KMS::Client).to receive(:new).and_return(kms_client)
+        allow(kms_client).to receive(:decrypt).with(ciphertext_blob: Base64.decode64(private_key_enc)).and_return(kms_response)
       end
 
-      it 'decrypts with KMS' do
-        decrypted_secrets = decrypt(ejson_tempfile.path, use_kms: true)
-        expect(decrypted_secrets[:secret]).to eq 'sssh!'
-      end
-    end
-
-    context 'when the stdout of ejson contains invalid JSON' do
-      let(:decrypted_secrets) { '{"api_key_1": "my-secret-api-key", "' }
-
-      before do
-        allow(Open3).to receive(:capture2).and_return([decrypted_secrets, double(success?: true)])
-      end
-
-      it "doesn't throw an error with the contents of the decrypted JSON" do
-        expect { decrypt(ejson_tempfile.path) }.to raise_error { |error|
-          expect(error.message).to_not include('my-secret-api-key')
-        }
-      end
-
-      it 'throws a decryption failed error' do
-        expect {
-          decrypt(ejson_tempfile.path)
-        }.to raise_error(EJSONWrapper::DecryptionFailed, /Failed to parse/)
+      it 'prints out the private key' do
+        Dir.mktmpdir do |key_dir|
+          File.write(File.join(key_dir, public_key), private_key)
+          key = reveal_key(ejson_tempfile.path, region: 'us-east-1')
+          expect(key).to eq private_key
+        end
       end
     end
   end


### PR DESCRIPTION
To export the private key for backup, we need to decrypt it via KMS first.
Add a command to make the process simpler.

Also:
- fix error string
- remove bundler restriction (works fine with bundler 2.x in other projects)