### PR TITLE
Adding rotate functionality for kms keys

### DIFF
--- a/exe/ejson_wrapper
+++ b/exe/ejson_wrapper
@@ -10,7 +10,7 @@ options = {
   kms_key_id: nil
 }
 option_parser = OptionParser.new do |opts|
-  opts.banner = 'Usage: ejson_wrapper {generate,decrypt,reveal_key} [options]'
+  opts.banner = 'Usage: ejson_wrapper {generate,decrypt,reveal_key,rotate_key} [options]'
 
   opts.on('--region R', String, 'AWS Region') do |v|
     options[:region] = v
@@ -26,6 +26,10 @@ option_parser = OptionParser.new do |opts|
 
   opts.on('--secret S', String, 'Secret to extract') do |v|
     options[:secret] = v
+  end
+
+  opts.on('--create-key C', TrueClass, "Set to true to create a new key for key rotation") do |v|
+    options[:create_key] = v
   end
 end
 
@@ -74,6 +78,17 @@ when 'reveal_key'
     puts EJSONWrapper.private_key_decrypted(options[:file], region: options[:region])
   rescue Errno::ENOENT
     STDERR.puts "Secrets file not found"
+    exit 1
+  end
+
+when 'rotate_key'
+  if options[:create_key]
+    EJSONWrapper.rotate_key(options[:file], options[:region], create_key: options[:create_key])
+  elsif options[:kms_key_id]
+    EJSONWrapper.rotate_key(options[:file], options[:region], kms_key_id: options[:kms_key_id])
+  else
+    STDERR.puts "ERROR: Missing option, use either --create-key true or --kms-key-id option"
+    STDERR.puts option_parser
     exit 1
   end
 

--- a/lib/ejson_wrapper.rb
+++ b/lib/ejson_wrapper.rb
@@ -2,6 +2,7 @@ require "ejson_wrapper/version"
 require "ejson_wrapper/decrypt_private_key_with_kms"
 require "ejson_wrapper/decrypt_ejson_file"
 require "ejson_wrapper/generate"
+require "ejson_wrapper/rotate"
 
 module EJSONWrapper
   def self.decrypt(file_path, key_dir: nil, private_key: nil, use_kms: false, region: nil)
@@ -17,5 +18,9 @@ module EJSONWrapper
 
   def self.private_key_decrypted(file_path, region: nil)
     DecryptPrivateKeyWithKMS.call(file_path, region: region)
+  end
+
+  def self.rotate_key(file_path, region, kms_key_id: nil, create_key: false)
+    Rotate.new.call(file_path, region, kms_key_id, create_key)
   end
 end

--- a/lib/ejson_wrapper/rotate.rb
+++ b/lib/ejson_wrapper/rotate.rb
@@ -1,0 +1,37 @@
+require 'open3'
+
+module EJSONWrapper
+
+  class Rotate
+    def call(ejson_file, region, kms_key_id, create_key)
+      decrypted = EJSONWrapper.decrypt(ejson_file, use_kms: true, region: region)
+      if create_key
+        kms_key_id = rotate_symmetric_key(region)
+      end
+      STDOUT.puts "Using the kms key #{kms_key_id}"
+      new_ejson_file = "temp.ejson"
+      EJSONWrapper.generate(region: region, kms_key_id: kms_key_id, file: new_ejson_file)
+      new_ejson = JSON.parse(File.read(new_ejson_file)).merge(decrypted)
+      File.open(new_ejson_file,"w") do |f|
+        f.puts JSON.pretty_generate(new_ejson)
+      end
+      cmd = ['ejson', 'encrypt', new_ejson_file]
+      stdout, status = Open3.capture2e(*cmd)
+      if !status.success? then
+        STDERR.puts "Encrypting failed: #{status} #{stdout}. Not replacing old file"
+      else
+        STDOUT.puts "Encryption succeeded for #{new_ejson_file}. Replacing old file"
+        File.delete(ejson_file)
+        File.rename(new_ejson_file, ejson_file)
+      end
+    end
+
+    private
+
+    def rotate_symmetric_key(region)
+      kms_client = Aws::KMS::Client.new(region: region)
+      new_kms_key = kms_client.create_key
+      new_kms_key.key_metadata.key_id
+    end
+  end
+end

--- a/lib/ejson_wrapper/rotate.rb
+++ b/lib/ejson_wrapper/rotate.rb
@@ -19,6 +19,7 @@ module EJSONWrapper
       stdout, status = Open3.capture2e(*cmd)
       if !status.success? then
         STDERR.puts "Encrypting failed: #{status} #{stdout}. Not replacing old file"
+        File.delete(new_ejson_file)
       else
         STDOUT.puts "Encryption succeeded for #{new_ejson_file}. Replacing old file"
         File.delete(ejson_file)


### PR DESCRIPTION
Changes are made to add a new command rotate_key with options file, region, create_key / kms_key_id. 
Functionality :
     This command can be used when we need to change the kms key that is used to generate an ejson file. We can either specify a kms key and the file would be decrypted and regenerated with the given key or either use the create_key option to create a kms key and use that.

$ ejson_wrapper rotate_key --file [file_name] --region [region_code] --kms-key-id [key_id] 
                                                            (or)
$ ejson_wrapper rotate_key --file [file_name] --region [region_code] --create-key true

Using the kms key [key_id]
Generated EJSON file temp.ejson
Encryption succeeded for temp.ejson. Replacing old file 