### PR TITLE
Add base64 as a runtime dependency

### DIFF
--- a/ejson_wrapper.gemspec
+++ b/ejson_wrapper.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ejson"
   spec.add_dependency "aws-sdk-kms"
+  spec.add_dependency "base64"
 end

--- a/lib/ejson_wrapper/version.rb
+++ b/lib/ejson_wrapper/version.rb
@@ -1,3 +1,3 @@
 module EjsonWrapper
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
### Context

EjsonWrapper uses the `base64` library from the Ruby standard library:

https://github.com/envato/ejson_wrapper/blob/9799a3b7ddb445a6d0768fab5a289dc4f15073dc/lib/ejson_wrapper/decrypt_private_key_with_kms.rb#L2

In the forthcoming Ruby 3.4, the `base64` library will be come a 'bundled' library. It must be included in gem sets to be used with Bundler.

In [Ruby 3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) a deprecation warning is shown:

> warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.

Example: https://github.com/envato/ejson_wrapper/actions/runs/7643628676/job/20826109584#step:4:6

### Change

Add `base64` as a runtime dependency in the gemspec.